### PR TITLE
Timestamp hidden by log bars

### DIFF
--- a/src/timeline/Timeline.tsx
+++ b/src/timeline/Timeline.tsx
@@ -63,7 +63,7 @@ export const Timeline = <EID extends string, LID extends string, E extends Timel
   zoomLevels = defaultOrderedZoomLevels,
   isTrimming = false,
   trimRange,
-  layers = ['grid', 'axes', 'interaction', 'marks'],
+  layers = ['grid', 'axes', 'marks', 'interaction'],
   theme = createTimelineTheme(),
   enabledInteractions,
   onEventHover = noOp,

--- a/src/timeline/layers/interaction/MouseCursor.tsx
+++ b/src/timeline/layers/interaction/MouseCursor.tsx
@@ -124,15 +124,15 @@ const ZoomCursor = ({
         height="100%"
         cursor={cursor}
       />
-      <line style={cursorStyle} x1={mousePosition} y1="0%" x2={mousePosition} y2="5%" cursor={cursor} />
+      <line style={cursorStyle} x1={mousePosition} y1="0%" x2={mousePosition} y2="3%" cursor={cursor} />
       <CursorLabel
         x={mousePosition}
-        y={isZoomInPossible ? '11%' : '15%'}
+        y={isZoomInPossible ? '7%' : '12%'}
         cursor={cursor}
         overline={cursorLabel}
         label={isZoomInPossible ? zoomScale : ''}
       />
-      <line style={cursorStyle} x1={mousePosition} y1="23%" x2={mousePosition} y2="100%" cursor={cursor} />
+      <line style={cursorStyle} x1={mousePosition} y1="16%" x2={mousePosition} y2="100%" cursor={cursor} />
     </g>
   )
 }


### PR DESCRIPTION
Resolves https://github.com/waabi-ai/data-platform/issues/1144

Brought text to front, increased height of logbars

Visualized in storybook:

before:
<img width="500" height="345" alt="Screenshot 2026-01-26 at 5 48 48 PM" src="https://github.com/user-attachments/assets/d64837fa-d5aa-4541-9089-58b38e4a73ef" />

after:
<img width="1049" height="345" alt="Screenshot 2026-01-26 at 5 48 09 PM" src="https://github.com/user-attachments/assets/2ef2e220-1084-42b0-bb50-27fee700e7e9" />
